### PR TITLE
Use single instance of Identifier

### DIFF
--- a/src/NTextCat-Http/NTextCat.NancyHandler/LanguageBootstrapper.cs
+++ b/src/NTextCat-Http/NTextCat.NancyHandler/LanguageBootstrapper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Nancy;
+using Nancy.TinyIoc;
+using NTextCat.NancyHandler.LanguageDetection;
+
+namespace NTextCat.NancyHandler
+{
+    public class LanguageBootstrapper : DefaultNancyBootstrapper
+    {
+        protected override void ConfigureApplicationContainer(TinyIoCContainer container)
+        {
+            base.ConfigureApplicationContainer(container);
+            container.Register<LanguageDetector>().AsSingleton();
+        }
+    }
+}
+

--- a/src/NTextCat-Http/NTextCat.NancyHandler/LanguageDetection/LanguageDetector.cs
+++ b/src/NTextCat-Http/NTextCat.NancyHandler/LanguageDetection/LanguageDetector.cs
@@ -11,18 +11,18 @@ namespace NTextCat.NancyHandler.LanguageDetection
     {
         private readonly INTextCatMatchingProfileLoader _profileLoader;
         private readonly DetectedLanguageBuilder _builder;
+        private readonly RankedLanguageIdentifier _identifier;
 
         public LanguageDetector(INTextCatMatchingProfileLoader profileLoader, DetectedLanguageBuilder builder)
         {
             _profileLoader = profileLoader;
             _builder = builder;
+            _identifier = new RankedLanguageIdentifierFactory().Load(_profileLoader.MatchingProfileFile);
         }
 
         public DetectedLanguageResponse DetectLanguage(LanguageDetectRequest model)
         {
-            var identifier = new RankedLanguageIdentifierFactory().Load(_profileLoader.MatchingProfileFile);
-
-            IEnumerable<Tuple<LanguageInfo, double>> matches = identifier.Identify(model.TextForLanguageClassification);
+            IEnumerable<Tuple<LanguageInfo, double>> matches = _identifier.Identify(model.TextForLanguageClassification);
             DetectedLanguageResponse detectedLanguageResponse = FormatResponse(matches, model);
 
             return detectedLanguageResponse;

--- a/src/NTextCat-Http/NTextCat.NancyHandler/NTextCat.NancyHandler.csproj
+++ b/src/NTextCat-Http/NTextCat.NancyHandler/NTextCat.NancyHandler.csproj
@@ -65,6 +65,7 @@
     <Compile Include="LanguageDetectModule.cs" />
     <Compile Include="LanguageDetection\LanguageDetectRequest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="LanguageBootstrapper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Was hitting performance problems on mono otherwise.
Create the identifier in the contructor and ensure LanguageDetector is
singleton.